### PR TITLE
Clean up account edit form and fix account deletion

### DIFF
--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -58,16 +58,16 @@ class AccountDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :email,
-    :encrypted_password,
+    #:encrypted_password,
     :admin,
-    :reset_password_token,
-    :reset_password_sent_at,
-    :remember_created_at,
-    :sign_in_count,
-    :current_sign_in_at,
-    :last_sign_in_at,
-    :current_sign_in_ip,
-    :last_sign_in_ip,
+    #:reset_password_token,
+    #:reset_password_sent_at,
+    #:remember_created_at,
+    #:sign_in_count,
+    #:current_sign_in_at,
+    #:last_sign_in_at,
+    #:current_sign_in_ip,
+    #:last_sign_in_ip,
   ].freeze
 
   # Overwrite this method to customize how accounts are displayed

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,8 +1,6 @@
 class Account < ApplicationRecord
   include Validators
 
-  has_and_belongs_to_many :oauth_credentials, dependent: :destroy
-
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :trackable, :timeoutable, :omniauthable, :database_authenticatable


### PR DESCRIPTION
- Had to remove `NameError in Admin::AccountsController#destroy
  uninitialized constant Account::OauthCredential`

  because we were getting

  `NameError in Admin::AccountsController#destroy uninitialized constant Account::OauthCredential`

  Besides, this was only found in one example of an Google Oauth2
  implementation.