### PR TITLE
Use auto_strip_attributes to strip spaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'omniauth'
 gem 'omniauth-google-oauth2'
 gem 'ancestry'
 gem 'cancancan', '~> 2.0'
+gem 'auto_strip_attributes'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    auto_strip_attributes (2.4.0)
+      activerecord (>= 4.0)
     autoprefixer-rails (8.6.4)
       execjs
     bcrypt (3.1.12)
@@ -339,6 +341,7 @@ PLATFORMS
 DEPENDENCIES
   administrate
   ancestry
+  auto_strip_attributes
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.0)
   byebug

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,6 +7,8 @@ class Account < ApplicationRecord
 
   validates :email, presence: true, email: true
 
+  auto_strip_attributes :email
+
   def self.from_omniauth(access_token)
     data = access_token.info
     account = Account.where(email: data['email']).first

--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -4,4 +4,6 @@ class Building < ApplicationRecord
   validates :name, :description, :address1, :temple_building_code, :directions_map, :hours, :image, :campus, :accessibility, presence: true
 	validates :email, presence: true, email: true
 	validates :phone_number, presence: true, phone_number: true
+
+  auto_strip_attributes :email
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,6 +7,8 @@ class Group < ApplicationRecord
  	validates :spaces, presence: true
 	validates :chair_dept_head, presence: true
 
+	auto_strip_attributes :email_address
+
   has_many :member
   has_many :persons, through: :member, source: :person
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -6,6 +6,8 @@ class Person < ApplicationRecord
  	validates :phone_number, presence: true, phone_number: true
  	validates :spaces, presence: true
 
+  auto_strip_attributes :email_address
+
   has_many :member
   has_many :groups, through: :member, source: :group
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -7,6 +7,8 @@ class Space < ApplicationRecord
  	validates :phone_number, presence: true, phone_number: true
   validates :building_id, presence: true
 
+  auto_strip_attributes :email
+
   belongs_to :building
 
   has_many :occupant

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe Building, type: :model do
         building.email = "abc"
         expect { building.save! }.to raise_error(/Email is not an email/)
       end
+      example "strip email with trailing blank" do
+        building.email = "chas@example.edu "
+        expect { building.save! }.to_not raise_error
+      end
       example "invalid email - blank " do
         building.email = ""
         expect { building.save! }.to raise_error(/Email can't be blank/)


### PR DESCRIPTION
Issue #LWR-129 - Strip out leading or trailing spaces so that email address can be validated.