### PR TITLE
Fixes broken specs from monkey patch merge

### DIFF
--- a/spec/dashboards/building_dashboard_spec.rb
+++ b/spec/dashboards/building_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe BuildingDashboard do #, type: :controller do
+RSpec.describe BuildingDashboard do
   describe "#tinymce?" do
     it "returns the local override value" do
       expect(BuildingDashboard.new.tinymce?).to be true

--- a/spec/dashboards/building_dashboard_spec.rb
+++ b/spec/dashboards/building_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe BuildingDashboard do
+RSpec.describe BuildingDashboard do #, type: :controller do
   describe "#tinymce?" do
     it "returns the local override value" do
       expect(BuildingDashboard.new.tinymce?).to be true

--- a/spec/dashboards/person_dashboard_spec.rb
+++ b/spec/dashboards/person_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe BaseDashboard do
+RSpec.describe BaseDashboard do #, type: :controller do
   describe "#tinymce?" do
     it "returns the default value" do
       expect(described_class.new.tinymce?).to be false

--- a/spec/dashboards/person_dashboard_spec.rb
+++ b/spec/dashboards/person_dashboard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe BaseDashboard do #, type: :controller do
+RSpec.describe BaseDashboard do
   describe "#tinymce?" do
     it "returns the default value" do
       expect(described_class.new.tinymce?).to be false

--- a/spec/monkey_patches/administrate_field_base_spec.rb
+++ b/spec/monkey_patches/administrate_field_base_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'administrate/field/string'
 
-describe Administrate::Field::String do
+RSpec.describe Administrate::Field::String do
   let(:field){ Administrate::Field::String.new(:string, "hello", :new, (options|| {})) }
 
   describe "#html_attributes" do


### PR DESCRIPTION
- Fixed broken specs that merge induced.  Errors were

An error occurred while loading the committed files. Must use 
`Rspec.describe` block
`