### PR TITLE
Specify OAuth Redirection URI in ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@ Fortytude is the Temple University Library's website built on Ruby on Rails.
 ```
 export GOOGLE_OAUTH_CLIENT_ID="Google client ID goes here"
 export GOOGLE_OAUTH_SECRET="Google OAuth secret goes here"
+export GOOGLE_OAUTH_REDIRECT_URI="Google OAuth Redirection URI goes here -- Set below"
 ```
+
 Add these same lines to your `.bash_profile` or `.bashrc` file, depending on
-how you've setup your Bash shell:
+how you've setup your Bash shell.
+
+Set your `GOOGLE_OAUTH_REDIRECT_URI` to the fully qualified domain name of the Rails application server
+Include port, if applicable, and path. If is not set, it will default to
+`http://localhost:3000/accounts/auth/google_oauth2`.
 
 * Clone the repository and navigate to the souce code directory
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,10 @@ Fortytude is the Temple University Library's website built on Ruby on Rails.
 ```
 export GOOGLE_OAUTH_CLIENT_ID="Google client ID goes here"
 export GOOGLE_OAUTH_SECRET="Google OAuth secret goes here"
-export GOOGLE_OAUTH_REDIRECT_URI="Google OAuth Redirection URI goes here -- Set below"
 ```
 
 Add these same lines to your `.bash_profile` or `.bashrc` file, depending on
 how you've setup your Bash shell.
-
-Set your `GOOGLE_OAUTH_REDIRECT_URI` to the fully qualified domain name of the Rails application server
-Include port, if applicable, and path. If is not set, it will default to
-`http://localhost:3000/accounts/auth/google_oauth2`.
 
 * Clone the repository and navigate to the souce code directory
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def google_oauth_redirect_uri
+    ENV.fetch("GOOGLE_OAUTH_REDIRECT_URI") { "http://localhost:3000/accounts/auth/google_oauth2" }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,2 @@
 module ApplicationHelper
-  def google_oauth_redirect_uri
-    return "#{request.env['rack.url_scheme']}://#{request.env["HTTP_HOST"]}/accounts/auth/google_oauth2"
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def google_oauth_redirect_uri
-    ENV.fetch('GOOGLE_OAUTH_REDIRECT_URI') { 'http://localhost:3000/accounts/auth/google_oauth2' }
+    return "#{request.env['rack.url_scheme']}://#{request.env["HTTP_HOST"]}/accounts/auth/google_oauth2"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def google_oauth_redirect_uri
-    ENV.fetch("GOOGLE_OAUTH_REDIRECT_URI") { "http://localhost:3000/accounts/auth/google_oauth2" }
+    ENV.fetch('GOOGLE_OAUTH_REDIRECT_URI') { 'http://localhost:3000/accounts/auth/google_oauth2' }
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Redirect to TUAccess" %>
 <% content_for :head do %>
-  <meta http-equiv="refresh" content="0; url=http://localhost:3000/accounts/auth/google_oauth2" />
+  <meta http-equiv="refresh" content="0; url=<%= google_oauth_redirect_uri %>" />
 <% end %>
 <h2>Log in with TU Access</h2>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Redirect to TUAccess" %>
 <% content_for :head do %>
-  <meta http-equiv="refresh" content="0; url=<%= google_oauth_redirect_uri %>" />
+  <meta http-equiv="refresh" content="0; url=<%= root_url %>accounts/auth/google_oauth2" />
 <% end %>
 <h2>Log in with TU Access</h2>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Redirect to TUAccess" %>
 <% content_for :head do %>
-  <meta http-equiv="refresh" content="0; url=<%= root_url %>accounts/auth/google_oauth2" />
+  <meta http-equiv="refresh" content="0; url=<%= account_google_oauth2_omniauth_authorize_url %>" />
 <% end %>
 <h2>Log in with TU Access</h2>
 


### PR DESCRIPTION
Currently we are hardcoding the Redirect URI in code that's in source control. This should take care of that problem code by specifying the URI as an environment variable. If not specified, URI defaults to `http://localhost:3000/accounts/auth/google_oauth2`.