### PR TITLE
Re-enable description validation

### DIFF
--- a/app/models/building.rb
+++ b/app/models/building.rb
@@ -5,7 +5,7 @@ class Building < ApplicationRecord
   validates :name, :address1, :temple_building_code, :directions_map, :hours, :campus, presence: true
 	validates :email, presence: true, email: true
 	validates :phone_number, presence: true, phone_number: true
-  # TODO implement: validates :description, presence: true
+  validates :description, presence: true
 
 	has_one_attached :photo, dependent: :destroy
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -4,7 +4,7 @@ class Space < ApplicationRecord
   has_ancestry
 
   validates :name, :hours, presence: true
-  # TODO implement: validates :description, presence: true
+  validates :description, presence: true
  	validates :email, email: true
  	validates :phone_number, phone_number: true
   validates :building_id, presence: true

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Building, type: :model do
     ]
     required_fields.each do |f|
       example "missing #{f} field" do
-        skip "Need to implement presence validation for `#{f}`" if ["description"].include?(f)
         building = FactoryBot.build(:building)
 				building[f] = ""
         expect { building.save! }.to raise_error(/#{f.humanize(capitalize: true)} can't be blank/)

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Space, type: :model do
     ]
     required_fields.each do |f|
       example "missing #{f} fields" do
-        skip "Need to implement presence validation for `#{f}`" if ["description"].include?(f)
         space = FactoryBot.build(:space)
 				space[f] = ""
         expect { space.save! }.to raise_error(/#{f.humanize(capitalize: true)} can't be blank/)


### PR DESCRIPTION
Restores required description field validation we had to take out when required wasn't working with text fields.